### PR TITLE
Drop ffmpeg extension

### DIFF
--- a/io.github.Loganavter.Improve-ImgSLI.yaml
+++ b/io.github.Loganavter.Improve-ImgSLI.yaml
@@ -5,12 +5,6 @@ sdk: org.kde.Sdk
 base: com.riverbankcomputing.PyQt.BaseApp
 base-version: '6.10'
 command: Improve-ImgSLI
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    version: '24.08'
-    add-ld-path: .
-    no-autodownload: false
 
 finish-args:
   - --socket=fallback-x11


### PR DESCRIPTION
Runtime version 6.10 already provides it. No longer required to be manually added.