### PR TITLE
Improve cleanup commands

### DIFF
--- a/io.github.Loganavter.Improve-ImgSLI.yaml
+++ b/io.github.Loganavter.Improve-ImgSLI.yaml
@@ -24,6 +24,11 @@ cleanup:
   - /share/pkgconfig
   - '*.la'
   - '*.a'
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+build-options:
+  env:
+    - BASEAPP_REMOVE_WEBENGINE=1
 modules:
   - name: openblas
     buildsystem: cmake-ninja

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -6,6 +6,7 @@
         {
             "name": "python3-pybind11",
             "buildsystem": "simple",
+            "cleanup": ["*"],
             "build-commands": [
                 "pip3 install --verbose --ignore-installed --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pybind11==2.13.2\" --no-build-isolation"
             ],
@@ -62,6 +63,7 @@
         {
             "name": "python3-meson-python",
             "buildsystem": "simple",
+            "cleanup": ["*"],
             "build-commands": [
                 "pip3 install --verbose --ignore-installed --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"meson-python==0.18.0\" --no-build-isolation"
             ],


### PR DESCRIPTION
- Clean up baseApp development files
- Clean up Baseapp Web Engine
- Clean up meson-python and pybind modules

> While it's not required, it's possible to set the environment variable BASEAPP_REMOVE_WEBENGINE to have the
BaseApp-cleanup.sh script remove the PyQtWebEngine bindings and QtWebEngine with its dependencies.

https://github.com/flathub/com.riverbankcomputing.PyQt.BaseApp/?tab=readme-ov-file#example-pyqt-application

**This patch is intended to reduce the Flatpak size. Please don't forget to test before merging. I'm not sure about the QtWebEngine part.**

